### PR TITLE
Figure styling

### DIFF
--- a/inst/shiny/server.R
+++ b/inst/shiny/server.R
@@ -237,7 +237,7 @@ server <- shinyServer(function(input, output, session) {
              xaxis = list(title = "wavenumber [cm<sup>-1</sup>]",
                           autorange = "reversed"),
              plot_bgcolor = 'rgb(17,0,73)',
-             paper_bgcolor = 'transparent',
+             paper_bgcolor = 'rgba(0,0,0,0.5)',
              font = list(color = '#FFFFFF'))
   })
   
@@ -255,7 +255,7 @@ server <- shinyServer(function(input, output, session) {
              xaxis = list(title = "wavenumber [cm<sup>-1</sup>]",
                           autorange = "reversed"),
              plot_bgcolor = 'rgb(17,0,73)',
-             paper_bgcolor = 'transparent',
+             paper_bgcolor = 'rgba(0,0,0,0.5)',
              font = list(color = '#FFFFFF')) %>%
       config(modeBarButtonsToAdd = list("drawopenpath", "eraseshape" ))
   })
@@ -370,7 +370,7 @@ observeEvent(input$go, {
                xaxis = list(title = "wavenumber [cm<sup>-1</sup>]",
                             autorange = "reversed"),
                plot_bgcolor='rgb(17,0, 73)',
-               paper_bgcolor='transparent',
+               paper_bgcolor= 'rgba(0,0,0,0.5)',
                font = list(color = '#FFFFFF'))
     }
     else if(length(input$event_rows_selected)) {

--- a/inst/shiny/server.R
+++ b/inst/shiny/server.R
@@ -404,7 +404,7 @@ observeEvent(input$go, {
                xaxis = list(title = "wavenumber [cm<sup>-1</sup>]",
                             autorange = "reversed"),
                plot_bgcolor = "rgb(17,0, 73)",
-               paper_bgcolor = "transparent",
+               paper_bgcolor = 'rgba(0,0,0,0.5)',
                font = list(color = "#FFFFFF"))
     }})
 

--- a/inst/shiny/server.R
+++ b/inst/shiny/server.R
@@ -497,6 +497,19 @@ observeEvent(input$go, {
       hide("range_tools")
     }
   })
+  
+  observe({
+    if (is.null(data())) {
+      show("placeholder1")
+      show("placeholder2")
+      show("placeholder3")
+    } else {
+      hide("placeholder1")
+      hide("placeholder2")
+      hide("placeholder3")
+    }
+  })
+  
   #This toggles the hidden metadata input layers.
   observeEvent(input$share_meta, {
     sapply(names(namekey)[c(1:24,32)], function(x) toggle(x))

--- a/inst/shiny/ui.R
+++ b/inst/shiny/ui.R
@@ -88,10 +88,20 @@ appCSS <-
 
 containerfunction <- function(...) {
   div(
-    style = "padding:8rem",
+    style = "padding:5rem",
     div(class = "jumbotron jumbotron-fluid",
         style = "border:solid #f7f7f9;background-color:rgba(0, 0, 0, 0.5)",
         align = "justify", ... ))
+}
+
+plotcontainerfunction <- function(...) {
+  div(
+    #style = "padding:5rem",
+    div(class = "front",
+        style = "border:solid #f7f7f9;background-color:rgba(0, 0, 0, 0.5)",
+        align = "justify", 
+        ...)
+    )
 }
 
 columnformat <- function() {
@@ -279,9 +289,9 @@ ui <- fluidPage(
 
               #Upload File Tab ----
               tabPanel("Upload File", value = "tab1",
-                       titlePanel(h4("Upload, View and Share Spectra")),
+                       titlePanel(h4("Upload, View and Share Spectra", align = "center")),
                        fluidRow(
-                         column(2, style = columnformat(),
+                         column(3, style = columnformat(),
                                 tags$label("Choose .csv (preferred), .asp, .jdx, .spc, .spa, or .0 File"),
 
                                 prettySwitch("share_decision",
@@ -448,8 +458,8 @@ ui <- fluidPage(
                                 ),
 
 
-                         column(10,
-                                plotlyOutput('MyPlot'),
+                         column(9,
+                                plotcontainerfunction(plotlyOutput('MyPlot')),
                                 style = bodyformat()
 
                          ),
@@ -467,9 +477,9 @@ ui <- fluidPage(
 
               #Preprocess Spectrum Tab ----
               tabPanel("Preprocess Spectrum", value = "tab2",
-                       titlePanel(tags$h4("Smooth, Baseline Correct, and Download Processed Spectra")),
+                       titlePanel(h4("Smooth, Baseline Correct, and Download Processed Spectra", align = "center")),
                        fluidRow(
-                           column(2, style = columnformat(),
+                           column(3, style = columnformat(),
                                 fluidRow(
                                   column(12,
                                   downloadButton('downloadData', 'Download (recommended)'),
@@ -586,8 +596,8 @@ ui <- fluidPage(
                             ),
 
 
-                         column(10,
-                                plotlyOutput('MyPlotB'),
+                         column(9,
+                                plotcontainerfunction(plotlyOutput('MyPlotB')),
                                 #verbatimTextOutput(outputId = "text"),
                                 style = bodyformat()
 
@@ -604,9 +614,9 @@ ui <- fluidPage(
 
               #Match Spectrum Tab ----
               tabPanel("Match Spectrum",value = "tab3",
-                       titlePanel(tags$h4("Identify Spectrum Using the Reference Library")),
+                       titlePanel(h4("Identify Spectrum Using the Reference Library", align = "center")),
                        fluidRow(
-                         column(2, style = columnformat(),
+                         column(3, style = columnformat(),
                                 radioButtons("Spectra", "Spectrum Type",
                                              c("Raman" = "raman",
                                                "FTIR" = "ftir")),
@@ -637,20 +647,18 @@ ui <- fluidPage(
                                   content = c("This selection will determine whether the library you are matching to consists of the full spectrum or only spectrum peaks."),
                                   placement = "bottom",
                                   trigger = "hover"
-                                )
+                                ),
+                                DT::dataTableOutput('event')
 
                          ),
 
-                         column(7,
-
-                                plotlyOutput('MyPlotC'),
-                                DT::dataTableOutput('eventmetadata'),
+                         column(9,
+                                plotcontainerfunction(plotlyOutput('MyPlotC'),
+                                                      DT::dataTableOutput('eventmetadata')),
                                 style = bodyformat()
 
+                         )
                          ),
-                         column(3, DT::dataTableOutput('event'),
-                                style = bodyformat()
-                                )),
 
 
                        hr(),

--- a/inst/shiny/ui.R
+++ b/inst/shiny/ui.R
@@ -617,7 +617,9 @@ ui <- fluidPage(
                        titlePanel(h4("Identify Spectrum Using the Reference Library", align = "center")),
                        fluidRow(
                          column(3, style = columnformat(),
-                                radioButtons("Spectra", "Spectrum Type",
+                                fluidRow(
+                                  column(4, 
+                                          radioButtons("Spectra", "Type",
                                              c("Raman" = "raman",
                                                "FTIR" = "ftir")),
                                 bsPopover(
@@ -626,8 +628,9 @@ ui <- fluidPage(
                                   content = c("This selection will determine whether the FTIR or Raman matching library is used. Choose the spectrum type that was uploaded."),
                                   placement = "bottom",
                                   trigger = "hover"
-                                ),
-                                radioButtons("Data", "Spectrum to Analyze",
+                                )),
+                                column(4, 
+                                       radioButtons("Data", "Analysis",
                                             c("Processed" = "processed",
                                               "Uploaded" = "uploaded"
                                             )),
@@ -638,18 +641,24 @@ ui <- fluidPage(
                                   placement = "bottom",
                                   trigger = "hover"
                                 ),
-                                radioButtons("Library", "Region to Match",
-                                            c("Full Spectrum" = "full",
-                                              "Peaks Only" = "peaks")),
+                                       ),
+                                column(4,
+                                       radioButtons("Library", "Region",
+                                            c("Full" = "full",
+                                              "Peaks" = "peaks")),
                                 bsPopover(
                                   id = "Library",
                                   title = "Region to Match Help",
                                   content = c("This selection will determine whether the library you are matching to consists of the full spectrum or only spectrum peaks."),
                                   placement = "bottom",
                                   trigger = "hover"
+                                )
+                                       
+                                    )
                                 ),
-                                DT::dataTableOutput('event')
-
+                                fluidRow(
+                                   DT::dataTableOutput('event')
+                                )
                          ),
 
                          column(9,

--- a/inst/shiny/ui.R
+++ b/inst/shiny/ui.R
@@ -289,7 +289,8 @@ ui <- fluidPage(
 
               #Upload File Tab ----
               tabPanel("Upload File", value = "tab1",
-                       titlePanel(h4("Upload, View and Share Spectra", align = "center")),
+                       titlePanel(h4("Upload, View, and Share Spectra")),
+                       br(),
                        fluidRow(
                          column(3, style = columnformat(),
                                 tags$label("Choose .csv (preferred), .asp, .jdx, .spc, .spa, or .0 File"),
@@ -459,7 +460,7 @@ ui <- fluidPage(
 
 
                          column(9,
-                                plotcontainerfunction(plotlyOutput('MyPlot')),
+                                plotcontainerfunction(h4(id = "placeholder1", "Upload some data to get started..."), plotlyOutput('MyPlot')),
                                 style = bodyformat()
 
                          ),
@@ -477,7 +478,8 @@ ui <- fluidPage(
 
               #Preprocess Spectrum Tab ----
               tabPanel("Preprocess Spectrum", value = "tab2",
-                       titlePanel(h4("Smooth, Baseline Correct, and Download Processed Spectra", align = "center")),
+                       titlePanel(h4("Smooth, Baseline Correct, and Download Processed Spectra")),
+                       br(),
                        fluidRow(
                            column(3, style = columnformat(),
                                 fluidRow(
@@ -597,7 +599,7 @@ ui <- fluidPage(
 
 
                          column(9,
-                                plotcontainerfunction(plotlyOutput('MyPlotB')),
+                                plotcontainerfunction(h4(id = "placeholder2", "Upload some data to get started..."), plotlyOutput('MyPlotB')),
                                 #verbatimTextOutput(outputId = "text"),
                                 style = bodyformat()
 
@@ -614,7 +616,8 @@ ui <- fluidPage(
 
               #Match Spectrum Tab ----
               tabPanel("Identify Spectrum",value = "tab3",
-                       titlePanel(h4("Identify Spectrum Using the Reference Library", align = "center")),
+                       titlePanel(h4("Identify Spectrum Using the Reference Library")),
+                       br(),
                        fluidRow(
                          column(3, style = columnformat(),
                                 fluidRow(
@@ -662,7 +665,7 @@ ui <- fluidPage(
                          ),
 
                          column(9,
-                                plotcontainerfunction(plotlyOutput('MyPlotC'),
+                                plotcontainerfunction(h4(id = "placeholder3", "Upload some data to get started..."), plotlyOutput('MyPlotC'),
                                                       DT::dataTableOutput('eventmetadata')),
                                 style = bodyformat()
 

--- a/inst/shiny/ui.R
+++ b/inst/shiny/ui.R
@@ -96,9 +96,9 @@ containerfunction <- function(...) {
 
 plotcontainerfunction <- function(...) {
   div(
-    #style = "padding:5rem",
+    #style = "padding:0.1rem",
     div(class = "front",
-        style = "border:solid #f7f7f9;background-color:rgba(0, 0, 0, 0.5)",
+        style = "border:solid #f7f7f9;background-color:rgba(0, 0, 0, 0.5);padding:1rem",
         align = "justify", 
         ...)
     )
@@ -613,7 +613,7 @@ ui <- fluidPage(
                        )),
 
               #Match Spectrum Tab ----
-              tabPanel("Match Spectrum",value = "tab3",
+              tabPanel("Identify Spectrum",value = "tab3",
                        titlePanel(h4("Identify Spectrum Using the Reference Library", align = "center")),
                        fluidRow(
                          column(3, style = columnformat(),
@@ -656,7 +656,7 @@ ui <- fluidPage(
                                        
                                     )
                                 ),
-                                fluidRow(
+                                fluidRow(style = "padding:1rem",
                                    DT::dataTableOutput('event')
                                 )
                          ),

--- a/inst/shiny/ui.R
+++ b/inst/shiny/ui.R
@@ -97,7 +97,7 @@ containerfunction <- function(...) {
 plotcontainerfunction <- function(...) {
   div(
     #style = "padding:0.1rem",
-    div(class = "front",
+    div(class = "jumbotron jumbotron-fluid",
         style = "border:solid #f7f7f9;background-color:rgba(0, 0, 0, 0.5);padding:1rem",
         align = "justify", 
         ...)


### PR DESCRIPTION
Added the comments from #68 to all plots, rearranged the match tab to make it a little cleaner and more effectively use the space. Also added borders to the plots which I have wanted to do for a while and made all plots the same size so that users can accurately transition from one view to the next without having distortions in the spectra between pages. Let me know what you think @zsteinmetz 