### PR TITLE
Fix occasional errors on CRAN

### DIFF
--- a/tests/testthat/test-manage_lib.R
+++ b/tests/testthat/test-manage_lib.R
@@ -5,14 +5,16 @@ tmp <- file.path(tempdir(), "OpenSpecy-testthat")
 dir.create(tmp, showWarnings = F)
 
 test_that("stop if OSF not reachable", {
+  skip_on_cran()
   skip_if_not(is.null(curl::nslookup("api.osf.io", error = F)),
               message = "OSF is online")
 
-  expect_error(load_lib(which = "test", type = c("metadata", "library"),
-                        path = tmp))
+  expect_error(get_lib(which = "test", type = c("metadata", "library"),
+                       path = tmp))
 })
 
 test_that("get_lib() downloads test library", {
+  skip_on_cran()
   skip_if_offline(host = "api.osf.io")
 
   expect_message(
@@ -22,6 +24,7 @@ test_that("get_lib() downloads test library", {
 })
 
 test_that("check_lib() finds test library", {
+  skip_on_cran()
   skip_if_offline(host = "api.osf.io")
 
   expect_silent(check_lib(which = "test", type = c("metadata", "library"),
@@ -31,6 +34,7 @@ test_that("check_lib() finds test library", {
 })
 
 test_that("load_lib() works as expected", {
+  skip_on_cran()
   skip_if_offline(host = "api.osf.io")
 
   expect_silent(tl <- load_lib(which = "test", type = c("metadata", "library"),


### PR DESCRIPTION
Skip tests on CRAN if they require an internet ressource